### PR TITLE
Lower Node requirement from 24 to 22

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "",
   "license": "MIT",
   "engines": {
-    "node": ">=24.0.0"
+    "node": ">=22.0.0"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.0.4",


### PR DESCRIPTION
I ran into the Node 24 requirement while setting this up with Claude Code. Before forcing the install, I dug through the source to see if there were any actual Node 24-specific features being used.

Didn't find any - the codebase uses standard APIs that have been stable since Node 18 (net.Socket, EventEmitter, fs/promises, etc.). No URLPattern, no experimental features that stabilized in 24.

Tested on Node 22.18.0:
- `npm install` completes (with warning, obviously)
- `npm run build` succeeds  
- LSP connection works, diagnostics come back correctly

This should make adoption easier since a lot of folks are still on Node 22 LTS.