### PR TITLE
WSL path normalization

### DIFF
--- a/src/diagnostics-manager.ts
+++ b/src/diagnostics-manager.ts
@@ -5,6 +5,7 @@ import fg from 'fast-glob';
 import { LSPClient } from './lsp-client.js';
 import { Diagnostic } from './types.js';
 import { getWorkspaceFromCwd } from './workspace-detection.js';
+import { normalizePath } from './path-utils.js';
 
 const WORKSPACE_NOT_FOUND_ERROR =
   'Workspace not found. Auto-detects if running from project root, otherwise set GODOT_WORKSPACE_PATH:\n' +
@@ -28,7 +29,8 @@ export class DiagnosticsManager {
     lspClient.on('workspaceChange', (params: unknown) => {
       const oldPath = this.workspacePath;
       if (params && typeof params === 'object' && 'path' in params) {
-        this.workspacePath = params.path as string;
+        // Normalize Windows paths to WSL format if running on WSL
+        this.workspacePath = normalizePath(params.path as string);
         if (oldPath !== this.workspacePath) {
           console.error(`[DiagnosticsManager] Workspace changed: ${oldPath || '(none)'} -> ${this.workspacePath}`);
         }
@@ -42,10 +44,12 @@ export class DiagnosticsManager {
    * Set workspace path (from gdscript_client/changeWorkspace or env var)
    */
   setWorkspace(path: string): void {
-    if (!existsSync(path)) {
-      console.error(`[DiagnosticsManager] Warning: Workspace path does not exist: ${path}`);
+    // Normalize Windows paths to WSL format if running on WSL
+    const normalizedPath = normalizePath(path);
+    if (!existsSync(normalizedPath)) {
+      console.error(`[DiagnosticsManager] Warning: Workspace path does not exist: ${normalizedPath}`);
     }
-    this.workspacePath = path;
+    this.workspacePath = normalizedPath;
     this.workspaceDetectionAttempted = true;
   }
 

--- a/src/path-utils.ts
+++ b/src/path-utils.ts
@@ -2,6 +2,8 @@
  * Utilities for handling cross-platform paths, especially WSL/Windows conversions
  */
 
+import { readFileSync } from 'fs';
+
 /**
  * Normalize a Windows path to WSL format if running on WSL
  * E.g., "E:/Work/project" -> "/mnt/e/Work/project"
@@ -39,13 +41,59 @@ export function normalizeToWindowsPath(path: string): string {
 }
 
 /**
+ * Decide whether we are running under WSL, given the ambient signals.
+ *
+ * Pure function so the decision can be tested without a WSL machine;
+ * `isWSL()` supplies the real inputs.
+ *
+ * Both signals are needed: WSL_DISTRO_NAME is absent when the process is
+ * spawned by a Windows parent (which is exactly the Godot-on-Windows case),
+ * and /proc/version is unreadable under some sandboxes.
+ */
+export function detectWSL(
+  platform: string,
+  procVersion: string | null,
+  wslDistroName?: string
+): boolean {
+  if (platform !== 'linux') {
+    return false;
+  }
+  if (wslDistroName !== undefined && wslDistroName !== '') {
+    return true;
+  }
+  // WSL1 reports "Microsoft", WSL2 reports "microsoft-standard-WSL2".
+  return procVersion !== null && procVersion.toLowerCase().includes('microsoft');
+}
+
+function readProcVersion(): string | null {
+  try {
+    return readFileSync('/proc/version', 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+let wslCache: boolean | null = null;
+
+/**
+ * Whether this process is running under WSL. Memoized - the answer cannot
+ * change during a process lifetime.
+ */
+export function isWSL(): boolean {
+  if (wslCache === null) {
+    wslCache = detectWSL(process.platform, readProcVersion(), process.env.WSL_DISTRO_NAME);
+  }
+  return wslCache;
+}
+
+/**
  * Normalize path to the current platform's format
  * Detects WSL automatically and converts Windows paths if needed
  */
 export function normalizePath(path: string): string {
-  // If we're on WSL (process.platform === 'linux' but /mnt/c exists),
-  // convert Windows paths to WSL paths
-  if (process.platform === 'linux') {
+  // Only rewrite drive-letter paths when actually on WSL. Plain Linux has no
+  // /mnt/<drive> mapping, so rewriting there would invent a bogus path.
+  if (isWSL()) {
     return normalizeToWSLPath(path);
   }
 
@@ -54,6 +102,6 @@ export function normalizePath(path: string): string {
     return normalizeToWindowsPath(path);
   }
 
-  // On other platforms (Mac, etc.), return as-is
+  // On plain Linux, macOS, etc., return as-is
   return path;
 }

--- a/src/path-utils.ts
+++ b/src/path-utils.ts
@@ -1,0 +1,59 @@
+/**
+ * Utilities for handling cross-platform paths, especially WSL/Windows conversions
+ */
+
+/**
+ * Normalize a Windows path to WSL format if running on WSL
+ * E.g., "E:/Work/project" -> "/mnt/e/Work/project"
+ */
+export function normalizeToWSLPath(path: string): string {
+  // Check if this looks like a Windows path (e.g., E:/ or E:\)
+  const windowsPathMatch = path.match(/^([A-Za-z]):[/\\]/);
+
+  if (windowsPathMatch) {
+    const driveLetter = windowsPathMatch[1].toLowerCase();
+    // Convert E:/path/to/file to /mnt/e/path/to/file
+    const pathWithoutDrive = path.slice(3); // Remove "E:/"
+    const unixPath = pathWithoutDrive.replace(/\\/g, '/');
+    return `/mnt/${driveLetter}/${unixPath}`.replace(/\/+/g, '/'); // Clean up double slashes
+  }
+
+  return path;
+}
+
+/**
+ * Normalize a WSL path to Windows format if needed
+ * E.g., "/mnt/e/Work/project" -> "E:/Work/project"
+ */
+export function normalizeToWindowsPath(path: string): string {
+  // Check if this is a WSL mount path
+  const wslPathMatch = path.match(/^\/mnt\/([a-z])\/(.*)$/);
+
+  if (wslPathMatch) {
+    const driveLetter = wslPathMatch[1].toUpperCase();
+    const pathAfterDrive = wslPathMatch[2];
+    return `${driveLetter}:/${pathAfterDrive}`;
+  }
+
+  return path;
+}
+
+/**
+ * Normalize path to the current platform's format
+ * Detects WSL automatically and converts Windows paths if needed
+ */
+export function normalizePath(path: string): string {
+  // If we're on WSL (process.platform === 'linux' but /mnt/c exists),
+  // convert Windows paths to WSL paths
+  if (process.platform === 'linux') {
+    return normalizeToWSLPath(path);
+  }
+
+  // On Windows, convert WSL paths to Windows paths
+  if (process.platform === 'win32') {
+    return normalizeToWindowsPath(path);
+  }
+
+  // On other platforms (Mac, etc.), return as-is
+  return path;
+}

--- a/tests/path-utils.test.ts
+++ b/tests/path-utils.test.ts
@@ -1,0 +1,210 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import { readFileSync } from 'node:fs';
+import {
+  normalizeToWSLPath,
+  normalizeToWindowsPath,
+  normalizePath,
+  detectWSL,
+  isWSL,
+} from '../src/path-utils.js';
+
+const WSL2_PROC_VERSION =
+  'Linux version 5.15.153.1-microsoft-standard-WSL2 (root@build) #1 SMP';
+const WSL1_PROC_VERSION = 'Linux version 4.4.0-19041-Microsoft (root@build) #1 SMP';
+const NATIVE_PROC_VERSION = 'Linux version 7.1.2-arch3-1 (linux@archlinux) #1 SMP PREEMPT';
+
+describe('path-utils', () => {
+  describe('normalizeToWSLPath', () => {
+    it('should convert a forward-slash Windows path', () => {
+      assert.strictEqual(normalizeToWSLPath('E:/Work/project'), '/mnt/e/Work/project');
+    });
+
+    it('should convert a backslash Windows path', () => {
+      assert.strictEqual(normalizeToWSLPath('E:\\Work\\project'), '/mnt/e/Work/project');
+    });
+
+    it('should convert mixed separators', () => {
+      assert.strictEqual(normalizeToWSLPath('E:/Work\\project/game.gd'), '/mnt/e/Work/project/game.gd');
+    });
+
+    it('should lowercase the drive letter', () => {
+      assert.strictEqual(normalizeToWSLPath('C:/Users/dev'), '/mnt/c/Users/dev');
+    });
+
+    it('should accept an already-lowercase drive letter', () => {
+      assert.strictEqual(normalizeToWSLPath('c:/Users/dev'), '/mnt/c/Users/dev');
+    });
+
+    it('should handle a bare drive root', () => {
+      assert.strictEqual(normalizeToWSLPath('E:/'), '/mnt/e/');
+    });
+
+    it('should collapse duplicate slashes', () => {
+      assert.strictEqual(normalizeToWSLPath('E://Work//project'), '/mnt/e/Work/project');
+    });
+
+    it('should preserve spaces in paths', () => {
+      assert.strictEqual(normalizeToWSLPath('E:/My Games/project'), '/mnt/e/My Games/project');
+    });
+
+    it('should leave POSIX paths untouched', () => {
+      assert.strictEqual(normalizeToWSLPath('/home/user/project'), '/home/user/project');
+    });
+
+    it('should leave already-converted WSL paths untouched', () => {
+      assert.strictEqual(normalizeToWSLPath('/mnt/e/Work/project'), '/mnt/e/Work/project');
+    });
+
+    it('should leave relative paths untouched', () => {
+      assert.strictEqual(normalizeToWSLPath('src/player.gd'), 'src/player.gd');
+    });
+
+    it('should leave UNC paths untouched', () => {
+      assert.strictEqual(normalizeToWSLPath('\\\\server\\share'), '\\\\server\\share');
+    });
+
+    it('should leave a drive letter with no separator untouched', () => {
+      // "E:foo" is a drive-relative path; there is no sane WSL equivalent.
+      assert.strictEqual(normalizeToWSLPath('E:foo'), 'E:foo');
+    });
+  });
+
+  describe('normalizeToWindowsPath', () => {
+    it('should convert a WSL mount path', () => {
+      assert.strictEqual(normalizeToWindowsPath('/mnt/e/Work/project'), 'E:/Work/project');
+    });
+
+    it('should uppercase the drive letter', () => {
+      assert.strictEqual(normalizeToWindowsPath('/mnt/c/Users/dev'), 'C:/Users/dev');
+    });
+
+    it('should handle a bare mount root', () => {
+      assert.strictEqual(normalizeToWindowsPath('/mnt/e/'), 'E:/');
+    });
+
+    it('should preserve spaces in paths', () => {
+      assert.strictEqual(normalizeToWindowsPath('/mnt/e/My Games/p'), 'E:/My Games/p');
+    });
+
+    it('should leave non-mount POSIX paths untouched', () => {
+      assert.strictEqual(normalizeToWindowsPath('/home/user/project'), '/home/user/project');
+    });
+
+    it('should leave Windows paths untouched', () => {
+      assert.strictEqual(normalizeToWindowsPath('E:/Work/project'), 'E:/Work/project');
+    });
+
+    it('should leave a mount root with no trailing slash untouched', () => {
+      // Documents current behaviour: the regex requires a slash after the drive.
+      assert.strictEqual(normalizeToWindowsPath('/mnt/e'), '/mnt/e');
+    });
+
+    it('should leave an uppercase mount letter untouched', () => {
+      // Documents current behaviour: WSL mounts are lowercase, so /mnt/E is
+      // not treated as a drive mapping.
+      assert.strictEqual(normalizeToWindowsPath('/mnt/E/Work'), '/mnt/E/Work');
+    });
+  });
+
+  describe('roundtrip', () => {
+    it('should roundtrip a Windows path through WSL form', () => {
+      const original = 'E:/Work/project/game.gd';
+      assert.strictEqual(normalizeToWindowsPath(normalizeToWSLPath(original)), original);
+    });
+
+    it('should roundtrip a WSL path through Windows form', () => {
+      const original = '/mnt/e/Work/project/game.gd';
+      assert.strictEqual(normalizeToWSLPath(normalizeToWindowsPath(original)), original);
+    });
+  });
+
+  describe('detectWSL', () => {
+    it('should detect WSL2 from /proc/version', () => {
+      assert.strictEqual(detectWSL('linux', WSL2_PROC_VERSION), true);
+    });
+
+    it('should detect WSL1 from /proc/version regardless of case', () => {
+      assert.strictEqual(detectWSL('linux', WSL1_PROC_VERSION), true);
+    });
+
+    it('should detect WSL from WSL_DISTRO_NAME when /proc/version is unreadable', () => {
+      // The Godot-on-Windows case: no env inherited, but also sandboxes where
+      // /proc is not mounted.
+      assert.strictEqual(detectWSL('linux', null, 'Ubuntu'), true);
+    });
+
+    it('should prefer WSL_DISTRO_NAME over a native /proc/version', () => {
+      assert.strictEqual(detectWSL('linux', NATIVE_PROC_VERSION, 'Ubuntu'), true);
+    });
+
+    it('should not detect WSL on native Linux', () => {
+      assert.strictEqual(detectWSL('linux', NATIVE_PROC_VERSION), false);
+    });
+
+    it('should not detect WSL when /proc/version is unreadable and no env var', () => {
+      assert.strictEqual(detectWSL('linux', null), false);
+    });
+
+    it('should treat an empty WSL_DISTRO_NAME as absent', () => {
+      assert.strictEqual(detectWSL('linux', NATIVE_PROC_VERSION, ''), false);
+    });
+
+    it('should never report WSL on win32', () => {
+      assert.strictEqual(detectWSL('win32', null, 'Ubuntu'), false);
+    });
+
+    it('should never report WSL on darwin', () => {
+      assert.strictEqual(detectWSL('darwin', WSL2_PROC_VERSION, 'Ubuntu'), false);
+    });
+  });
+
+  describe('isWSL', () => {
+    it('should return a boolean', () => {
+      assert.strictEqual(typeof isWSL(), 'boolean');
+    });
+
+    it('should be stable across calls (memoized)', () => {
+      assert.strictEqual(isWSL(), isWSL());
+    });
+
+    it('should agree with detectWSL on the current environment', () => {
+      assert.strictEqual(isWSL(), detectWSL(process.platform, procVersionOrNull(), process.env.WSL_DISTRO_NAME));
+    });
+  });
+
+  describe('normalizePath', () => {
+    it('should leave POSIX paths untouched on every platform', () => {
+      assert.strictEqual(normalizePath('/home/user/project'), '/home/user/project');
+    });
+
+    if (isWSL()) {
+      it('should convert Windows paths to WSL form under WSL', () => {
+        assert.strictEqual(normalizePath('E:/Work/project'), '/mnt/e/Work/project');
+      });
+    } else if (process.platform === 'win32') {
+      it('should convert WSL paths to Windows form on Windows', () => {
+        assert.strictEqual(normalizePath('/mnt/e/Work/project'), 'E:/Work/project');
+      });
+    } else {
+      it('should NOT rewrite drive-letter paths on native Linux or macOS', () => {
+        // Regression: the original port branched on `process.platform === 'linux'`
+        // alone, so a directory literally named "E:" on native Linux was rewritten
+        // to the non-existent /mnt/e/... path.
+        assert.strictEqual(normalizePath('E:/Work/project'), 'E:/Work/project');
+      });
+
+      it('should NOT rewrite /mnt paths on native Linux or macOS', () => {
+        assert.strictEqual(normalizePath('/mnt/e/Work/project'), '/mnt/e/Work/project');
+      });
+    }
+  });
+});
+
+function procVersionOrNull(): string | null {
+  try {
+    return readFileSync('/proc/version', 'utf8');
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
Godot and this MCP server can run on opposite sides of a WSL boundary, so the paths Godot reports aren't the paths the server can open. This PR normalizes incoming paths to the format the server's own platform expects.

The first commit is ported verbatim from [nguyennk in the Lotus-Bloom-Studio fork](https://github.com/Lotus-Bloom-Studio/minimal-godot-mcp/commit/4af4c5b9598b1968ba35c466a3dda03f72778af4), preserved with original authorship.

Follow-up commits are mine: the ported normalizePath() gated on process.platform === 'linux' alone; I replaced it with more robust WSL detection and added tests.

Known limitations
- `/mnt` is assumed to be the DrvFs mount root, but it's configurable via `automount.root` in `/etc/wsl.conf`.
- normalizeToWindowsPath requires a trailing slash and lowercase drive, so e.g., `/mnt/e` and `/mnt/E/Work` pass through unconverted. Asserted as current behaviour in tests.